### PR TITLE
feat(*): add support for battle.net eu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
-# Battle.Net OAuth (US) Extension
+# Battle.Net OAuth (US/EU) Extension
 
 ## Install
 
 1. Download the latest release.
 2. Unzip the downloaded release, and copy to your ext folder.
+(The files should now be located unter ./ext/AJHenderson/BattleNetOAuthUS/)
 3. Navigate in the ACP to `Customise -> Manage extensions`.
-4. Look for `Battle.Net US` under the Disabled Extensions list, and click its `Enable` link.
+4. Look for `Battle.Net US` or `Battle.Net EU` under the Disabled Extensions list, and click its `Enable` link.
 5. Go to dev.battle.net, login (or register if neccessary).
 6. Create a new application for your forum.  
 7. Specify the application url as the https url to your site.
 8. Specify the callback URL as "https://yoursite/ucp.php?i=ucp_auth_link&mode=auth_link&link=1&oauth_service=battlenet".
 (Note that you must be using HTTPS for Battle.Net to produce callback requests to your site.  Without them, oAuth will not work.)
-9. Take the key and secret provided for your new application and enter them in ACP under 'Client Communication -> Authentication' in the Battle.Net US fields.
+9. Take the key and secret provided for your new application and enter them in ACP under 'Client Communication -> Authentication' in the Battle.Net US/EU fields.
 
 ## Uninstall
 

--- a/auth/provider/oauth/service/battlenet_eu.php
+++ b/auth/provider/oauth/service/battlenet_eu.php
@@ -1,0 +1,101 @@
+<?php
+/**
+*
+*
+* @copyright (c) 2015 AJ Henderson
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+*
+*/
+
+namespace AJHenderson\BattleNetOAuthUS\auth\provider\oauth\service;
+
+/**
+* Battle.Net OAuth service
+*/
+class battlenet_eu extends \phpbb\auth\provider\oauth\service\base
+{
+	/**
+	* phpBB config
+	*
+	* @var \phpbb\config\config
+	*/
+	protected $config;
+
+	/**
+	* phpBB request
+	*
+	* @var \phpbb\request\request_interface
+	*/
+	protected $request;
+
+	/**
+	* phpBB user
+	*
+	* @var \phpbb\user
+	*/
+	protected $user;
+
+	/**
+	* Constructor
+	*
+	* @param	\phpbb\config\config				$config
+	* @param	\phpbb\request\request_interface	$request
+	* @param    \phpbb\user                         $user
+	*/
+	public function __construct(\phpbb\config\config $config, \phpbb\request\request_interface $request, \phpbb\user $user)
+	{
+		$this->config = $config;
+		$this->request = $request;
+		$this->user = $user;
+		$this->user->add_lang_ext('AJHenderson/BattleNetOAuthUS', 'common');
+	}
+
+	/**
+	* {@inheritdoc}
+	*/
+	public function get_service_credentials()
+	{
+		return array(
+			'key'		=> $this->config['auth_oauth_battleneteu_key'],
+			'secret'	=> $this->config['auth_oauth_battleneteu_secret'],
+		);
+	}
+
+	/**
+	* {@inheritdoc}
+	*/
+	public function perform_auth_login()
+	{
+		if (!($this->service_provider instanceof \OAuth\OAuth2\Service\BattleNetEU))
+		{
+			throw new \phpbb\auth\provider\oauth\service\exception('AUTH_PROVIDER_OAUTH_ERROR_INVALID_SERVICE_TYPE');
+		}
+
+		// This was a callback request from battlenet, get the token
+		$this->service_provider->requestAccessToken($this->request->variable('code', ''));
+
+		// Send a request with it
+		$result = json_decode($this->service_provider->request('account/user'), true);
+
+		// Return the unique identifier returned from battlenet
+		return $result['battletag'];
+	}
+
+	/**
+	* {@inheritdoc}
+	*/
+	public function perform_token_auth()
+	{
+		if (!($this->service_provider instanceof \OAuth\OAuth2\Service\BattleNetEU))
+		{
+			throw new \phpbb\auth\provider\oauth\service\exception('AUTH_PROVIDER_OAUTH_ERROR_INVALID_SERVICE_TYPE');
+		}
+
+		// Send a request with it
+		$result = json_decode($this->service_provider->request('account/user'), true);
+
+		// Return the unique identifier returned from battlenet
+		return $result['battletag'];
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "AJHenderson/BattleNetOAuthUS",
 	"type": "phpbb-extension",
-	"description": "Adds support for US Battle.Net OAuth logins.",
+	"description": "Adds support for US/EU Battle.Net OAuth logins.",
 	"homepage": "https://github.com/AJH16/PHPBB-BattleNet-OAuth",
 	"version": "1.0.0",
 	"license": "GPL-2.0",
@@ -21,7 +21,7 @@
 			"phpbb/epv": "dev-master"
 	},
 	"extra": {
-		"display-name": "Battle.Net OAuth(US)",
+		"display-name": "Battle.Net OAuth (US/EU)",
 		"soft-require": {
 			"phpbb/phpbb": ">=3.1.0"
 		}

--- a/config/services.yml
+++ b/config/services.yml
@@ -7,3 +7,11 @@ services:
             - @user
         tags:
             - { name: auth.provider.oauth.service }
+    auth.provider.oauth.service.battleneteu:
+        class: AJHenderson\BattleNetOAuthUS\auth\provider\oauth\service\battlenet_eu
+        arguments:
+            - @config
+            - @request
+            - @user
+        tags:
+            - { name: auth.provider.oauth.service }

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -16,4 +16,5 @@ if (empty($lang) || !is_array($lang))
 }
 $lang = array_merge($lang, array(
 	'AUTH_PROVIDER_OAUTH_SERVICE_BATTLENETUS'				=> 'Battle.Net US',
+	'AUTH_PROVIDER_OAUTH_SERVICE_BATTLENETEU'				=> 'Battle.Net EU',
 ));

--- a/vendor/OAuth/OAuth2/Service/Battleneteu.php
+++ b/vendor/OAuth/OAuth2/Service/Battleneteu.php
@@ -1,0 +1,18 @@
+<?php
+namespace OAuth\OAuth2\Service;
+
+use OAuth\Common\Http\Uri\Uri;
+use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Http\Client\ClientInterface;
+use OAuth\Common\Storage\TokenStorageInterface;
+use OAuth\Common\Http\Uri\UriInterface;
+
+class BattleNetEU extends BattleNetBase
+{
+	public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, $scopes = array(), UriInterface $baseApiUri = null)
+   	{
+  	    parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
+		$this->region = 'eu';
+		$this->baseApiUri = new Uri('https://' . $this->region . '.api.battle.net/');
+	}
+}


### PR DESCRIPTION
## Description

- adds support for region EU
- both regions can be activated separately or at a time

## TODO / thoughts

- extension / package should be renamed `AJHenderson/BattleNetOAuthUS` => `AJHenderson/BattleNetOAuth`, but that is a breaking change.
- add tests - separately for each region, but that explodes the test matrix => discuss